### PR TITLE
Next Release

### DIFF
--- a/.github/workflows/develop-func-ci.yml
+++ b/.github/workflows/develop-func-ci.yml
@@ -10,22 +10,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v2.4.0
-
-      - name: 'Setup Node Environment'
-        uses: actions/setup-node@v2.5.1
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: 'Install Dependencies with Npm'
-        run: |
-          npm i -g npm
-          npm set-script prepare ""
-          npm ci --production
+    uses: IATI/.github/.github/workflows/build_node_save.yaml@main
+    with:
+      save_artifact: false
 
   automerge:
     needs: build

--- a/.github/workflows/develop-func-deploy.yml
+++ b/.github/workflows/develop-func-deploy.yml
@@ -14,7 +14,6 @@ on:
 env:
   STAGE: dev # suffix to indicate environment stage
   NAME: func-iati-sitemapper
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.' # set this to the path to your web app project, defaults to the repository root
   SOLR_API_URL: ${{ secrets.DEV_SOLR_API_URL }}
   SOLR_USER: ${{ secrets.DEV_SOLR_NONADMIN_USER_NAME }}
   SOLR_PASSWORD: ${{ secrets.DEV_SOLR_NONADMIN_USER_PASSWORD }}
@@ -32,28 +31,27 @@ jobs:
   should_run:
     uses: IATI/.github/.github/workflows/should_run.yaml@main
 
-  build-deploy:
+  build_save:
     needs: should_run
     if: ${{ needs.should_run.outputs.should_run == 'true' }}
+    uses: IATI/.github/.github/workflows/build_node_save.yaml@main
+    with:
+      save_artifact: true
+      artifact_name: build-artifact-dev
+
+  deploy:
+    needs: build_save
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v2.4.0
-
-      - name: 'Setup Node Environment'
-        uses: actions/setup-node@v2.5.1
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          name: build-artifact-dev
 
-      - name: 'Resolve Project Dependencies Using Npm'
-        shell: bash
+      - name: Unzip build artifact
         run: |
-          npm i -g npm
-          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
-          npm set-script prepare ""
-          npm ci --production
-          popd
+          unzip build-artifact-dev.zip
+          rm build-artifact-dev.zip
 
       - name: 'Login via Azure CLI'
         uses: azure/login@v1.4.3
@@ -142,10 +140,9 @@ jobs:
         uses: Azure/functions-action@v1.4.4
         with:
           app-name: ${{ env.NAME }}-${{ env.STAGE }}
-          package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
 
   integration-test:
-    needs: build-deploy
+    needs: deploy
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
@@ -161,11 +158,11 @@ jobs:
 
   # Mark status checks success/fail on dependabot commits for scheduled deploys
   status_check_success:
-    needs: [build-deploy, integration-test]
+    needs: [deploy, integration-test]
     if: success() && github.event_name == 'schedule'
     uses: IATI/.github/.github/workflows/status_check_success.yaml@main
 
   status_check_failure:
-    needs: [build-deploy, integration-test]
+    needs: [deploy, integration-test]
     if: failure() && github.event_name == 'schedule'
     uses: IATI/.github/.github/workflows/status_check_failure.yaml@main

--- a/.github/workflows/prod-func-deploy.yml
+++ b/.github/workflows/prod-func-deploy.yml
@@ -7,7 +7,6 @@ on:
 env:
   STAGE: PROD # suffix to indicate environment stage
   NAME: func-iati-sitemapper
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.' # set this to the path to your web app project, defaults to the repository root
   SOLR_API_URL: ${{ secrets.PROD_SOLR_API_URL }}
   SOLR_USER: ${{ secrets.PROD_SOLR_NOADMIN_USER }}
   SOLR_PASSWORD: ${{ secrets.PROD_SOLR_NOADMIN_PASSWORD }}
@@ -22,26 +21,25 @@ env:
   VALIDATOR_SERVICES_API_KEY_VALUE: ${{ secrets.PROD_VALIDATOR_SERVICES_KEY_VALUE }}
 
 jobs:
-  build-deploy:
+  build_save:
+    uses: IATI/.github/.github/workflows/build_node_save.yaml@main
+    with:
+      save_artifact: true
+      artifact_name: build-artifact-prod
+
+  deploy:
+    needs: build_save
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v2.4.0
-
-      - name: 'Setup Node Environment'
-        uses: actions/setup-node@v2.5.1
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          name: build-artifact-prod
 
-      - name: 'Resolve Project Dependencies Using Npm'
-        shell: bash
+      - name: Unzip build artifact
         run: |
-          npm i -g npm
-          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
-          npm set-script prepare ""
-          npm ci --production
-          popd
+          unzip build-artifact-prod.zip
+          rm build-artifact-prod.zip
 
       - name: 'Login via Azure CLI'
         uses: azure/login@v1.4.3
@@ -130,10 +128,9 @@ jobs:
         uses: Azure/functions-action@v1.4.4
         with:
           app-name: ${{ env.NAME }}-${{ env.STAGE }}
-          package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
 
   integration-test:
-    needs: build-deploy
+    needs: deploy
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
-                "husky": "^8.0.1",
+                "husky": "^8.0.2",
                 "lint-staged": "^13.0.3",
                 "prettier": "^2.7.1"
             },
@@ -1387,9 +1387,9 @@
             }
         },
         "node_modules/husky": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-            "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+            "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
             "dev": true,
             "bin": {
                 "husky": "lib/bin.js"
@@ -3948,9 +3948,9 @@
             "dev": true
         },
         "husky": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-            "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+            "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
             "dev": true
         },
         "ignore": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "sitemapper",
             "version": "1.1.14",
             "dependencies": {
-                "dotenv": "^16.0.2",
+                "dotenv": "^16.0.3",
                 "node-fetch": "^3.2.10",
                 "redis": "^4.3.1"
             },
@@ -635,9 +635,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "16.0.2",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-            "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
             "engines": {
                 "node": ">=12"
             }
@@ -3489,9 +3489,9 @@
             }
         },
         "dotenv": {
-            "version": "16.0.2",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
-            "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+            "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
         },
         "emoji-regex": {
             "version": "9.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
-                "eslint": "^8.24.0",
+                "eslint": "^8.25.0",
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -28,9 +28,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-            "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+            "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -62,16 +62,6 @@
             },
             "engines": {
                 "node": ">=10.10.0"
-            }
-        },
-        "node_modules/@humanwhocodes/gitignore-to-minimatch": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-            "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -700,14 +690,13 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.24.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-            "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+            "version": "8.25.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+            "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.3.2",
+                "@eslint/eslintrc": "^1.3.3",
                 "@humanwhocodes/config-array": "^0.10.5",
-                "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
@@ -3039,9 +3028,9 @@
     },
     "dependencies": {
         "@eslint/eslintrc": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-            "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+            "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
@@ -3065,12 +3054,6 @@
                 "debug": "^4.1.1",
                 "minimatch": "^3.0.4"
             }
-        },
-        "@humanwhocodes/gitignore-to-minimatch": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-            "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-            "dev": true
         },
         "@humanwhocodes/module-importer": {
             "version": "1.0.1",
@@ -3539,14 +3522,13 @@
             }
         },
         "eslint": {
-            "version": "8.24.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-            "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+            "version": "8.25.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+            "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.3.2",
+                "@eslint/eslintrc": "^1.3.3",
                 "@humanwhocodes/config-array": "^0.10.5",
-                "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.1.15",
             "dependencies": {
                 "dotenv": "^16.0.3",
-                "node-fetch": "^3.2.10",
+                "node-fetch": "^3.3.0",
                 "redis": "^4.4.0"
             },
             "devDependencies": {
@@ -2055,9 +2055,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "3.2.10",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-            "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+            "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
             "dependencies": {
                 "data-uri-to-buffer": "^4.0.0",
                 "fetch-blob": "^3.1.4",
@@ -4416,9 +4416,9 @@
             "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
         },
         "node-fetch": {
-            "version": "3.2.10",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-            "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+            "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
             "requires": {
                 "data-uri-to-buffer": "^4.0.0",
                 "fetch-blob": "^3.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
-                "eslint": "^8.25.0",
+                "eslint": "^8.26.0",
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -51,9 +51,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.10.5",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz",
-            "integrity": "sha512-XVVDtp+dVvRxMoxSiSfasYaG02VEe1qH5cKgMQJWhol6HwzbcqoCMJi8dAGoYAO57jhUyhI6cWuRiTcRaDaYug==",
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
+            "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -320,15 +320,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/array.prototype.flat": {
@@ -600,18 +591,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -690,14 +669,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-            "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
+            "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
             "dev": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.10.5",
+                "@humanwhocodes/config-array": "^0.11.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -713,14 +693,14 @@
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
-                "glob-parent": "^6.0.1",
+                "glob-parent": "^6.0.2",
                 "globals": "^13.15.0",
-                "globby": "^11.1.0",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
+                "is-path-inside": "^3.0.3",
                 "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -1125,34 +1105,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
-        "node_modules/fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-glob/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1366,26 +1318,6 @@
             },
             "engines": {
                 "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -1673,6 +1605,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-regex": {
@@ -2043,15 +1984,6 @@
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
         },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/micromatch": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -2376,15 +2308,6 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2635,15 +2558,6 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
-        },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/slice-ansi": {
             "version": "5.0.0",
@@ -3045,9 +2959,9 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.10.5",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz",
-            "integrity": "sha512-XVVDtp+dVvRxMoxSiSfasYaG02VEe1qH5cKgMQJWhol6HwzbcqoCMJi8dAGoYAO57jhUyhI6cWuRiTcRaDaYug==",
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
+            "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -3243,12 +3157,6 @@
                 "get-intrinsic": "^1.1.1",
                 "is-string": "^1.0.7"
             }
-        },
-        "array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true
         },
         "array.prototype.flat": {
             "version": "1.2.5",
@@ -3453,15 +3361,6 @@
                 "object-keys": "^1.0.12"
             }
         },
-        "dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "requires": {
-                "path-type": "^4.0.0"
-            }
-        },
         "doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3522,14 +3421,15 @@
             }
         },
         "eslint": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-            "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+            "version": "8.26.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
+            "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
             "dev": true,
             "requires": {
                 "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.10.5",
+                "@humanwhocodes/config-array": "^0.11.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -3545,14 +3445,14 @@
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
-                "glob-parent": "^6.0.1",
+                "glob-parent": "^6.0.2",
                 "globals": "^13.15.0",
-                "globby": "^11.1.0",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
+                "is-path-inside": "^3.0.3",
                 "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -3848,30 +3748,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
-        "fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.1"
-                    }
-                }
-            }
-        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4027,20 +3903,6 @@
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
-            }
-        },
-        "globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "requires": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
             }
         },
         "grapheme-splitter": {
@@ -4227,6 +4089,12 @@
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
+        },
+        "is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true
         },
         "is-regex": {
             "version": "1.1.4",
@@ -4499,12 +4367,6 @@
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
         },
-        "merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true
-        },
         "micromatch": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -4730,12 +4592,6 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
-        "path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true
-        },
         "picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4893,12 +4749,6 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
-        },
-        "slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
         "slice-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "dotenv": "^16.0.3",
                 "node-fetch": "^3.2.10",
-                "redis": "^4.3.1"
+                "redis": "^4.4.0"
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
@@ -129,20 +129,20 @@
             }
         },
         "node_modules/@redis/bloom": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
-            "integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.1.0.tgz",
+            "integrity": "sha512-9QovlxmpRtvxVbN0UBcv8WfdSMudNZZTFqCsnBszcQXqaZb/TVe30ScgGEO7u1EAIacTPAo7/oCYjYAxiHLanQ==",
             "peerDependencies": {
                 "@redis/client": "^1.0.0"
             }
         },
         "node_modules/@redis/client": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
-            "integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.1.tgz",
+            "integrity": "sha512-FKEHpOu7Q4+cuM6VWjA54988K5jkqOxvhvj2hEGSx086lvKwXyjzO7Lya7hcirZ0/Db8FLBJN7UXsJuyoNWPJg==",
             "dependencies": {
-                "cluster-key-slot": "1.1.0",
-                "generic-pool": "3.8.2",
+                "cluster-key-slot": "1.1.1",
+                "generic-pool": "3.9.0",
                 "yallist": "4.0.0"
             },
             "engines": {
@@ -150,9 +150,9 @@
             }
         },
         "node_modules/@redis/graph": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
-            "integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.0.tgz",
+            "integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
             "peerDependencies": {
                 "@redis/client": "^1.0.0"
             }
@@ -482,9 +482,9 @@
             }
         },
         "node_modules/cluster-key-slot": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
-            "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+            "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1227,9 +1227,9 @@
             "dev": true
         },
         "node_modules/generic-pool": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
-            "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+            "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
             "engines": {
                 "node": ">= 4"
             }
@@ -2386,13 +2386,13 @@
             ]
         },
         "node_modules/redis": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
-            "integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-4.4.0.tgz",
+            "integrity": "sha512-tQyFG6O9iewLxxHYRyirJNklhe2QI7M/0o8q0jk7D9Z/Cxh/7oZrQyHKyjWz0TkkCls8ool/xvhL9K8zRnkaYQ==",
             "dependencies": {
-                "@redis/bloom": "1.0.2",
-                "@redis/client": "1.3.0",
-                "@redis/graph": "1.0.1",
+                "@redis/bloom": "1.1.0",
+                "@redis/client": "1.3.1",
+                "@redis/graph": "1.1.0",
                 "@redis/json": "1.0.4",
                 "@redis/search": "1.1.0",
                 "@redis/time-series": "1.0.3"
@@ -3018,25 +3018,25 @@
             }
         },
         "@redis/bloom": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.0.2.tgz",
-            "integrity": "sha512-EBw7Ag1hPgFzdznK2PBblc1kdlj5B5Cw3XwI9/oG7tSn85/HKy3X9xHy/8tm/eNXJYHLXHJL/pkwBpFMVVefkw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.1.0.tgz",
+            "integrity": "sha512-9QovlxmpRtvxVbN0UBcv8WfdSMudNZZTFqCsnBszcQXqaZb/TVe30ScgGEO7u1EAIacTPAo7/oCYjYAxiHLanQ==",
             "requires": {}
         },
         "@redis/client": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.0.tgz",
-            "integrity": "sha512-XCFV60nloXAefDsPnYMjHGtvbtHR8fV5Om8cQ0JYqTNbWcQo/4AryzJ2luRj4blveWazRK/j40gES8M7Cp6cfQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.1.tgz",
+            "integrity": "sha512-FKEHpOu7Q4+cuM6VWjA54988K5jkqOxvhvj2hEGSx086lvKwXyjzO7Lya7hcirZ0/Db8FLBJN7UXsJuyoNWPJg==",
             "requires": {
-                "cluster-key-slot": "1.1.0",
-                "generic-pool": "3.8.2",
+                "cluster-key-slot": "1.1.1",
+                "generic-pool": "3.9.0",
                 "yallist": "4.0.0"
             }
         },
         "@redis/graph": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.0.1.tgz",
-            "integrity": "sha512-oDE4myMCJOCVKYMygEMWuriBgqlS5FqdWerikMoJxzmmTUErnTRRgmIDa2VcgytACZMFqpAOWDzops4DOlnkfQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.0.tgz",
+            "integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
             "requires": {}
         },
         "@redis/json": {
@@ -3278,9 +3278,9 @@
             }
         },
         "cluster-key-slot": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
-            "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+            "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="
         },
         "color-convert": {
             "version": "2.0.1",
@@ -3842,9 +3842,9 @@
             "dev": true
         },
         "generic-pool": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
-            "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg=="
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+            "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
         },
         "get-intrinsic": {
             "version": "1.1.1",
@@ -4629,13 +4629,13 @@
             "dev": true
         },
         "redis": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/redis/-/redis-4.3.1.tgz",
-            "integrity": "sha512-cM7yFU5CA6zyCF7N/+SSTcSJQSRMEKN0k0Whhu6J7n9mmXRoXugfWDBo5iOzGwABmsWKSwGPTU5J4Bxbl+0mrA==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-4.4.0.tgz",
+            "integrity": "sha512-tQyFG6O9iewLxxHYRyirJNklhe2QI7M/0o8q0jk7D9Z/Cxh/7oZrQyHKyjWz0TkkCls8ool/xvhL9K8zRnkaYQ==",
             "requires": {
-                "@redis/bloom": "1.0.2",
-                "@redis/client": "1.3.0",
-                "@redis/graph": "1.0.1",
+                "@redis/bloom": "1.1.0",
+                "@redis/client": "1.3.1",
+                "@redis/graph": "1.1.0",
                 "@redis/json": "1.0.4",
                 "@redis/search": "1.1.0",
                 "@redis/time-series": "1.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
-                "eslint": "^8.27.0",
+                "eslint": "^8.28.0",
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -669,9 +669,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.27.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
-            "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+            "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
             "dev": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.3.3",
@@ -3421,9 +3421,9 @@
             }
         },
         "eslint": {
-            "version": "8.27.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
-            "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+            "version": "8.28.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+            "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
             "dev": true,
             "requires": {
                 "@eslint/eslintrc": "^1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "dotenv": "^16.0.3",
                 "node-fetch": "^3.3.0",
-                "redis": "^4.4.0"
+                "redis": "^4.5.0"
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
@@ -137,9 +137,9 @@
             }
         },
         "node_modules/@redis/client": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.1.tgz",
-            "integrity": "sha512-FKEHpOu7Q4+cuM6VWjA54988K5jkqOxvhvj2hEGSx086lvKwXyjzO7Lya7hcirZ0/Db8FLBJN7UXsJuyoNWPJg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.4.0.tgz",
+            "integrity": "sha512-1gEj1AkyXPlkcC/9/T5xpDcQF8ntERURjLBgEWMTdUZqe181zfI9BY3jc2OzjTLkvZh5GV7VT4ktoJG2fV2ufw==",
             "dependencies": {
                 "cluster-key-slot": "1.1.1",
                 "generic-pool": "3.9.0",
@@ -174,9 +174,9 @@
             }
         },
         "node_modules/@redis/time-series": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
-            "integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.4.tgz",
+            "integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
             "peerDependencies": {
                 "@redis/client": "^1.0.0"
             }
@@ -2386,16 +2386,16 @@
             ]
         },
         "node_modules/redis": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/redis/-/redis-4.4.0.tgz",
-            "integrity": "sha512-tQyFG6O9iewLxxHYRyirJNklhe2QI7M/0o8q0jk7D9Z/Cxh/7oZrQyHKyjWz0TkkCls8ool/xvhL9K8zRnkaYQ==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-4.5.0.tgz",
+            "integrity": "sha512-oZGAmOKG+RPnHo0UxM5GGjJ0dBd/Vi4fs3MYwM1p2baDoXC0wpm0yOdpxVS9K+0hM84ycdysp2eHg2xGoQ4FEw==",
             "dependencies": {
                 "@redis/bloom": "1.1.0",
-                "@redis/client": "1.3.1",
+                "@redis/client": "1.4.0",
                 "@redis/graph": "1.1.0",
                 "@redis/json": "1.0.4",
                 "@redis/search": "1.1.0",
-                "@redis/time-series": "1.0.3"
+                "@redis/time-series": "1.0.4"
             }
         },
         "node_modules/regexp-to-ast": {
@@ -3024,9 +3024,9 @@
             "requires": {}
         },
         "@redis/client": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.3.1.tgz",
-            "integrity": "sha512-FKEHpOu7Q4+cuM6VWjA54988K5jkqOxvhvj2hEGSx086lvKwXyjzO7Lya7hcirZ0/Db8FLBJN7UXsJuyoNWPJg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.4.0.tgz",
+            "integrity": "sha512-1gEj1AkyXPlkcC/9/T5xpDcQF8ntERURjLBgEWMTdUZqe181zfI9BY3jc2OzjTLkvZh5GV7VT4ktoJG2fV2ufw==",
             "requires": {
                 "cluster-key-slot": "1.1.1",
                 "generic-pool": "3.9.0",
@@ -3052,9 +3052,9 @@
             "requires": {}
         },
         "@redis/time-series": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.3.tgz",
-            "integrity": "sha512-OFp0q4SGrTH0Mruf6oFsHGea58u8vS/iI5+NpYdicaM+7BgqBZH8FFvNZ8rYYLrUO/QRqMq72NpXmxLVNcdmjA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.4.tgz",
+            "integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
             "requires": {}
         },
         "@types/json5": {
@@ -4629,16 +4629,16 @@
             "dev": true
         },
         "redis": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/redis/-/redis-4.4.0.tgz",
-            "integrity": "sha512-tQyFG6O9iewLxxHYRyirJNklhe2QI7M/0o8q0jk7D9Z/Cxh/7oZrQyHKyjWz0TkkCls8ool/xvhL9K8zRnkaYQ==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-4.5.0.tgz",
+            "integrity": "sha512-oZGAmOKG+RPnHo0UxM5GGjJ0dBd/Vi4fs3MYwM1p2baDoXC0wpm0yOdpxVS9K+0hM84ycdysp2eHg2xGoQ4FEw==",
             "requires": {
                 "@redis/bloom": "1.1.0",
-                "@redis/client": "1.3.1",
+                "@redis/client": "1.4.0",
                 "@redis/graph": "1.1.0",
                 "@redis/json": "1.0.4",
                 "@redis/search": "1.1.0",
-                "@redis/time-series": "1.0.3"
+                "@redis/time-series": "1.0.4"
             }
         },
         "regexp-to-ast": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sitemapper",
-    "version": "1.1.14",
+    "version": "1.1.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sitemapper",
-            "version": "1.1.14",
+            "version": "1.1.15",
             "dependencies": {
                 "dotenv": "^16.0.3",
                 "node-fetch": "^3.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
-                "eslint": "^8.26.0",
+                "eslint": "^8.27.0",
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -669,9 +669,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.26.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-            "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
+            "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
             "dev": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.3.3",
@@ -3421,9 +3421,9 @@
             }
         },
         "eslint": {
-            "version": "8.26.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-            "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+            "version": "8.27.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
+            "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
             "dev": true,
             "requires": {
                 "@eslint/eslintrc": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sitemapper",
-    "version": "1.1.14",
+    "version": "1.1.15",
     "description": "Dynamic sitemap function for static websites that need indexing",
     "type": "module",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",
-        "eslint": "^8.26.0",
+        "eslint": "^8.27.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "dotenv": "^16.0.3",
         "node-fetch": "^3.2.10",
-        "redis": "^4.3.1"
+        "redis": "^4.4.0"
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
-        "husky": "^8.0.1",
+        "husky": "^8.0.2",
         "lint-staged": "^13.0.3",
         "prettier": "^2.7.1"
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "author": "IATI",
     "dependencies": {
         "dotenv": "^16.0.3",
-        "node-fetch": "^3.2.10",
+        "node-fetch": "^3.3.0",
         "redis": "^4.4.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",
-        "eslint": "^8.25.0",
+        "eslint": "^8.26.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",
-        "eslint": "^8.27.0",
+        "eslint": "^8.28.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "author": "IATI",
     "dependencies": {
-        "dotenv": "^16.0.2",
+        "dotenv": "^16.0.3",
         "node-fetch": "^3.2.10",
         "redis": "^4.3.1"
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",
-        "eslint": "^8.24.0",
+        "eslint": "^8.25.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "dotenv": "^16.0.3",
         "node-fetch": "^3.3.0",
-        "redis": "^4.4.0"
+        "redis": "^4.5.0"
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",


### PR DESCRIPTION
- Bump eslint from 8.24.0 to 8.25.0 (#96)
- Bump eslint from 8.25.0 to 8.26.0 (#97)
- Bump redis from 4.3.1 to 4.4.0 (#98)
- Bump eslint from 8.26.0 to 8.27.0 (#99)
- Bump husky from 8.0.1 to 8.0.2 (#100)
- use reusable node build to fix npm error
- Bump node-fetch from 3.2.10 to 3.3.0 (#102)
- Bump redis from 4.4.0 to 4.5.0 (#103)
- Bump eslint from 8.27.0 to 8.28.0 (#105)
