### PR TITLE
Fix throw on idle disconnect, use keepalive and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ See OpenAPI specification `postman/schemas/index.yaml`. To view locally in Swagg
 -   Node LTS
     -   This will be the latest LTS version supported by Azure Functions, set in `.nvmrc`
     -   once you've installed nvm run `nvm use` which will look at `.nvmrc` for the node version, if it's not installed then it will prompt you to install it with `nvm install <version> --latest-npm`
--   npm >=8
+-   npm >=11
     -   nvm will install the version of npm packaged with node. make sure to use the `--latest-npm` flag to get the latest version
     -   If you forgot to do that install the latest version of npm with `npm i -g npm`
--   [Azure Functions Core Tools v3](https://github.com/Azure/azure-functions-core-tools)
+-   [Azure Functions Core Tools v4](https://github.com/Azure/azure-functions-core-tools)
 -   [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) version 2.4 or later.
 
 ## Getting Started

--- a/config/redis.js
+++ b/config/redis.js
@@ -1,12 +1,18 @@
 import { createClient } from 'redis';
 import config from './config.js';
 
-let connectionOptions = {};
+// Send a periodic PING and reconnect with a capped backoff so Azure Cache for Redis
+// (and the load balancer in front of it) doesn't reap the idle TLS connection, which
+// otherwise surfaces as SocketClosedUnexpectedlyError.
+const connectionOptions = {
+    pingInterval: 60000,
+    socket: {
+        reconnectStrategy: (retries) => Math.min(retries * 100, 3000),
+    },
+};
 if (config.REDIS_KEY && config.REDIS_HOSTNAME) {
-    connectionOptions = {
-        url: `rediss://${config.REDIS_HOSTNAME}:${config.REDIS_PORT}`,
-        password: config.REDIS_KEY,
-    };
+    connectionOptions.url = `rediss://${config.REDIS_HOSTNAME}:${config.REDIS_PORT}`;
+    connectionOptions.password = config.REDIS_KEY;
 }
 const client = createClient(connectionOptions);
 client.on('ready', () => {
@@ -15,9 +21,11 @@ client.on('ready', () => {
         value: `Redis: Connection to ${config.REDIS_HOSTNAME || 'local'} ready`,
     });
 });
+// Log connection errors but do NOT rethrow: an async throw here becomes an uncaught
+// exception that kills the Functions Node worker. The client reconnects via
+// reconnectStrategy on its own.
 client.on('error', (err) => {
     console.error('Redis: Unable to connect to the redis database: ', err);
-    throw err;
 });
 
 await client.connect();


### PR DESCRIPTION
The sitemapper previously threw an error if it couldn't connect to the `redis` database, but there was no keepalive on the `redis` connection, and `redis` will kill idle connections. The throwing of this error was causing lots of exceptions in the logs and causing the Functions worker to restart. This PR fixes that, and adds a keepalive to reduce the noise in the logs.

This will resolve https://github.com/IATI/sitemapper/issues/238